### PR TITLE
Serialize in the Browser session storage

### DIFF
--- a/SunFarmSite/Areas/SunFarmViews/Pages/ORDHDSPF.cshtml
+++ b/SunFarmSite/Areas/SunFarmViews/Pages/ORDHDSPF.cshtml
@@ -71,7 +71,7 @@
                 </div>
 
                 <nav class="tab-navigation">
-                    <button id="initial-tab" type="button" class="tab-links" onclick="openTab(event.currentTarget)">Customer Info</button>
+                    <button type="button" class="tab-links" onclick="openTab(event.currentTarget)">Customer Info</button>
                     <button type="button" class="tab-links" onclick="openTab(event.currentTarget)">Order List</button>
                 </nav>
 
@@ -179,5 +179,11 @@
 
 <script src="~/js/RecordTabs.js"></script>
 <script>
-    openTab(document.getElementById('initial-tab'));
+    let lastTabName = getLastTabNameFromSessionStorage();
+    if (!lastTabName) {
+        openTabByName('Customer Info');
+    }
+    else {
+        openTabByName(lastTabName);
+    }
 </script>

--- a/SunFarmSite/wwwroot/js/RecordTabs.js
+++ b/SunFarmSite/wwwroot/js/RecordTabs.js
@@ -1,8 +1,15 @@
 ﻿const openTab = (tabNavButton) => {
-    const tabPage = document.getElementById(tabNavButton.innerHTML);
+    if (!tabNavButton) {
+        return; // ignore.
+    }
+    openTabByName(tabNavButton.innerHTML);
+}
+
+const openTabByName = (reqPageName) => {
+    const tabPage = document.getElementById(reqPageName);
 
     if (tabPage) {
-        // Get all the elements with class="tab-content" and hide them
+        // Get all the elements with class="tab-content" and hide them.
         const tabcontent = document.querySelectorAll('[class~="tab-content"]');
         for (let i = 0, l = tabcontent.length; i < l; i++) {
             tabcontent[i].style.display = 'none';
@@ -10,12 +17,24 @@
 
         // Get all elements with class="tab-links" and remove the class "active"
         const tablinks = document.querySelectorAll('[class~="tab-links"]');
+        let tabNavButton = null;
         for (let i = 0, l = tablinks.length; i < l; i++) {
             tablinks[i].className = tablinks[i].className.replace(' active', '');
+            if (tablinks[i].innerHTML === reqPageName) {
+                tabNavButton = tablinks[i]; // Save the button that has the requested name.
+            }
         }
 
         // Show the current tab, and add an "active" class to the button that opened the tab.
         tabPage.style.display = 'block';
-        tabNavButton.className += ' active';
+        if (tabNavButton) {
+            tabNavButton.className += ' active';
+        }
+
+        sessionStorage.setItem(`SunFarmLastTabForPage:${window.location.pathname}`, reqPageName);
     }
+}
+
+const getLastTabNameFromSessionStorage = () => {
+    return sessionStorage.getItem(`SunFarmLastTabForPage:${window.location.pathname}`);
 }


### PR DESCRIPTION
When user opens a Tab, serialize in the Browser session storage the name of the Tab. This makes it possible to improve subfile paging.